### PR TITLE
tiff, bmp: return io.UnexpectedEOF on empty data

### DIFF
--- a/bmp/reader.go
+++ b/bmp/reader.go
@@ -144,6 +144,9 @@ func decodeConfig(r io.Reader) (config image.Config, bitsPerPixel int, topDown b
 	)
 	var b [1024]byte
 	if _, err := io.ReadFull(r, b[:fileHeaderLen+4]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return image.Config{}, 0, false, err
 	}
 	if string(b[:2]) != "BM" {
@@ -155,6 +158,9 @@ func decodeConfig(r io.Reader) (config image.Config, bitsPerPixel int, topDown b
 		return image.Config{}, 0, false, ErrUnsupported
 	}
 	if _, err := io.ReadFull(r, b[fileHeaderLen+4:fileHeaderLen+infoLen]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return image.Config{}, 0, false, err
 	}
 	width := int(int32(readUint32(b[18:22])))

--- a/bmp/reader_test.go
+++ b/bmp/reader_test.go
@@ -82,8 +82,12 @@ func TestDecode(t *testing.T) {
 //  when there are no headers or data is empty
 func TestEOF(t *testing.T) {
 	_, err := Decode(bytes.NewReader([]byte{}))
-
 	if err != io.ErrUnexpectedEOF {
 		t.Errorf("Error should be io.ErrUnexpectedEOF but got %v", err)
+	}
+
+	_, err = Decode(bytes.NewReader(nil))
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("Error should be io.ErrUnexpectedEOF on nil but got %v", err)
 	}
 }

--- a/bmp/reader_test.go
+++ b/bmp/reader_test.go
@@ -5,8 +5,10 @@
 package bmp
 
 import (
+	"bytes"
 	"fmt"
 	"image"
+	"io"
 	"os"
 	"testing"
 
@@ -73,5 +75,15 @@ func TestDecode(t *testing.T) {
 			t.Errorf("%s: %v", tc, err)
 			continue
 		}
+	}
+}
+
+// TestEOF tests that decoding a BMP image returns io.ErrUnexpectedEOF
+//  when there are no headers or data is empty
+func TestEOF(t *testing.T) {
+	_, err := Decode(bytes.NewReader([]byte{}))
+
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("Error should be io.ErrUnexpectedEOF but got %v", err)
 	}
 }

--- a/bmp/reader_test.go
+++ b/bmp/reader_test.go
@@ -81,12 +81,7 @@ func TestDecode(t *testing.T) {
 // TestEOF tests that decoding a BMP image returns io.ErrUnexpectedEOF
 //  when there are no headers or data is empty
 func TestEOF(t *testing.T) {
-	_, err := Decode(bytes.NewReader([]byte{}))
-	if err != io.ErrUnexpectedEOF {
-		t.Errorf("Error should be io.ErrUnexpectedEOF but got %v", err)
-	}
-
-	_, err = Decode(bytes.NewReader(nil))
+	_, err := Decode(bytes.NewReader(nil))
 	if err != io.ErrUnexpectedEOF {
 		t.Errorf("Error should be io.ErrUnexpectedEOF on nil but got %v", err)
 	}

--- a/bmp/reader_test.go
+++ b/bmp/reader_test.go
@@ -79,7 +79,7 @@ func TestDecode(t *testing.T) {
 }
 
 // TestEOF tests that decoding a BMP image returns io.ErrUnexpectedEOF
-//  when there are no headers or data is empty
+// when there are no headers or data is empty
 func TestEOF(t *testing.T) {
 	_, err := Decode(bytes.NewReader(nil))
 	if err != io.ErrUnexpectedEOF {

--- a/tiff/reader.go
+++ b/tiff/reader.go
@@ -404,6 +404,9 @@ func newDecoder(r io.Reader) (*decoder, error) {
 
 	p := make([]byte, 8)
 	if _, err := d.r.ReadAt(p, 0); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return nil, err
 	}
 	switch string(p[0:4]) {

--- a/tiff/reader_test.go
+++ b/tiff/reader_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"image"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -191,6 +192,16 @@ func TestDecodeLZW(t *testing.T) {
 	}
 
 	compare(t, img0, img1)
+}
+
+// TestEOF tests that decoding a TIFF image returns io.ErrUnexpectedEOF
+//  when there are no headers or data is empty
+func TestEOF(t *testing.T) {
+	_, err := Decode(bytes.NewReader([]byte{}))
+
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("Error should be io.ErrUnexpectedEOF but got %v", err)
+	}
 }
 
 // TestDecodeCCITT tests that decoding a PNG image and a CCITT compressed TIFF

--- a/tiff/reader_test.go
+++ b/tiff/reader_test.go
@@ -197,12 +197,7 @@ func TestDecodeLZW(t *testing.T) {
 // TestEOF tests that decoding a TIFF image returns io.ErrUnexpectedEOF
 //  when there are no headers or data is empty
 func TestEOF(t *testing.T) {
-	_, err := Decode(bytes.NewReader([]byte{}))
-	if err != io.ErrUnexpectedEOF {
-		t.Errorf("Error should be io.ErrUnexpectedEOF on empty []byte{} but got %v", err)
-	}
-
-	_, err = Decode(bytes.NewReader(nil))
+	_, err := Decode(bytes.NewReader(nil))
 	if err != io.ErrUnexpectedEOF {
 		t.Errorf("Error should be io.ErrUnexpectedEOF on nil but got %v", err)
 	}

--- a/tiff/reader_test.go
+++ b/tiff/reader_test.go
@@ -198,9 +198,13 @@ func TestDecodeLZW(t *testing.T) {
 //  when there are no headers or data is empty
 func TestEOF(t *testing.T) {
 	_, err := Decode(bytes.NewReader([]byte{}))
-
 	if err != io.ErrUnexpectedEOF {
-		t.Errorf("Error should be io.ErrUnexpectedEOF but got %v", err)
+		t.Errorf("Error should be io.ErrUnexpectedEOF on empty []byte{} but got %v", err)
+	}
+
+	_, err = Decode(bytes.NewReader(nil))
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("Error should be io.ErrUnexpectedEOF on nil but got %v", err)
 	}
 }
 

--- a/tiff/reader_test.go
+++ b/tiff/reader_test.go
@@ -195,7 +195,7 @@ func TestDecodeLZW(t *testing.T) {
 }
 
 // TestEOF tests that decoding a TIFF image returns io.ErrUnexpectedEOF
-//  when there are no headers or data is empty
+// when there are no headers or data is empty
 func TestEOF(t *testing.T) {
 	_, err := Decode(bytes.NewReader(nil))
 	if err != io.ErrUnexpectedEOF {


### PR DESCRIPTION
Check for an EOF when decoding the tiff and bmp headers,
so that decoding empty data does not return an EOF.

Fixes golang/go#11391