### PR TITLE
webp: don't reject VP8X that isn't just VP8 + alpha

### DIFF
--- a/webp/decode.go
+++ b/webp/decode.go
@@ -24,6 +24,11 @@ var (
 	fccVP8L = riff.FourCC{'V', 'P', '8', 'L'}
 	fccVP8X = riff.FourCC{'V', 'P', '8', 'X'}
 	fccWEBP = riff.FourCC{'W', 'E', 'B', 'P'}
+	fccICCP = riff.FourCC{'I', 'C', 'C', 'P'}
+	fccXMP  = riff.FourCC{'X', 'M', 'P', ' '}
+	fccANIM = riff.FourCC{'A', 'N', 'I', 'M'}
+	fccANMF = riff.FourCC{'A', 'N', 'M', 'F'}
+	fccEXIF = riff.FourCC{'E', 'X', 'I', 'F'}
 )
 
 func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
@@ -126,8 +131,8 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 				alphaBit        = 1 << 4
 				iccProfileBit   = 1 << 5
 			)
-			if buf[0] != alphaBit {
-				return nil, image.Config{}, errors.New("webp: non-Alpha VP8X is not implemented")
+			if buf[0] == alphaBit {
+				wantAlpha = true
 			}
 			widthMinusOne = uint32(buf[4]) | uint32(buf[5])<<8 | uint32(buf[6])<<16
 			heightMinusOne = uint32(buf[7]) | uint32(buf[8])<<8 | uint32(buf[9])<<16
@@ -138,8 +143,11 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 					Height:     int(heightMinusOne) + 1,
 				}, nil
 			}
-			wantAlpha = true
-
+		case fccICCP:
+		case fccXMP:
+		case fccANIM:
+		case fccANMF:
+		case fccEXIF:
 		default:
 			return nil, image.Config{}, errInvalidFormat
 		}

--- a/webp/decode.go
+++ b/webp/decode.go
@@ -130,8 +130,15 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 			widthMinusOne = uint32(buf[4]) | uint32(buf[5])<<8 | uint32(buf[6])<<16
 			heightMinusOne = uint32(buf[7]) | uint32(buf[8])<<8 | uint32(buf[9])<<16
 			if configOnly {
+				if wantAlpha {
+					return nil, image.Config{
+						ColorModel: color.NYCbCrAModel,
+						Width:      int(widthMinusOne) + 1,
+						Height:     int(heightMinusOne) + 1,
+					}, nil
+				}
 				return nil, image.Config{
-					ColorModel: color.NYCbCrAModel,
+					ColorModel: color.YCbCrModel,
 					Width:      int(widthMinusOne) + 1,
 					Height:     int(heightMinusOne) + 1,
 				}, nil

--- a/webp/decode.go
+++ b/webp/decode.go
@@ -24,11 +24,6 @@ var (
 	fccVP8L = riff.FourCC{'V', 'P', '8', 'L'}
 	fccVP8X = riff.FourCC{'V', 'P', '8', 'X'}
 	fccWEBP = riff.FourCC{'W', 'E', 'B', 'P'}
-	fccICCP = riff.FourCC{'I', 'C', 'C', 'P'}
-	fccXMP  = riff.FourCC{'X', 'M', 'P', ' '}
-	fccANIM = riff.FourCC{'A', 'N', 'I', 'M'}
-	fccANMF = riff.FourCC{'A', 'N', 'M', 'F'}
-	fccEXIF = riff.FourCC{'E', 'X', 'I', 'F'}
 )
 
 func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
@@ -131,9 +126,7 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 				alphaBit        = 1 << 4
 				iccProfileBit   = 1 << 5
 			)
-			if buf[0] == alphaBit {
-				wantAlpha = true
-			}
+			wantAlpha = (buf[0] & alphaBit) != 0
 			widthMinusOne = uint32(buf[4]) | uint32(buf[5])<<8 | uint32(buf[6])<<16
 			heightMinusOne = uint32(buf[7]) | uint32(buf[8])<<8 | uint32(buf[9])<<16
 			if configOnly {
@@ -143,13 +136,6 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 					Height:     int(heightMinusOne) + 1,
 				}, nil
 			}
-		case fccICCP:
-		case fccXMP:
-		case fccANIM:
-		case fccANMF:
-		case fccEXIF:
-		default:
-			return nil, image.Config{}, errInvalidFormat
 		}
 	}
 }


### PR DESCRIPTION
We already support VP8 + alpha, but reject e.g. VP8 + EXIF. After this
commit, we still don't implement VP8 + EXIF (or ANIM, ICCP, etc.), but
we now silently ignore the EXIF chunk instead of rejecting it.

Fixes golang/go#25738, golang/go#38341