### PR TITLE
x/image/tiff: Read/write support for JPEG-based compression (TIFF compression scheme 7)

### DIFF
--- a/tiff/consts.go
+++ b/tiff/consts.go
@@ -65,6 +65,9 @@ const (
 	tColorMap     = 320
 	tExtraSamples = 338
 	tSampleFormat = 339
+
+	// https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFFphotoshop.pdf
+	tJPEG = 347 // page 7
 )
 
 // Compression types (defined in various places in the spec and supplements).
@@ -130,6 +133,7 @@ const (
 	LZW
 	CCITTGroup3
 	CCITTGroup4
+	JPEG
 )
 
 // specValue returns the compression type constant from the TIFF spec that
@@ -144,6 +148,8 @@ func (c CompressionType) specValue() uint32 {
 		return cG3
 	case CCITTGroup4:
 		return cG4
+	case JPEG:
+		return cJPEG
 	}
 	return cNone
 }

--- a/tiff/consts.go
+++ b/tiff/consts.go
@@ -29,6 +29,8 @@ const (
 	dtShort    = 3
 	dtLong     = 4
 	dtRational = 5
+
+	dtUndefined = 7 // JPEGTables field is required to have type code UNDEFINED
 )
 
 // The length of one instance of each data type in bytes.

--- a/tiff/writer_test.go
+++ b/tiff/writer_test.go
@@ -75,6 +75,57 @@ func TestRoundtrip2(t *testing.T) {
 	compare(t, m0, m1)
 }
 
+func delta(u0, u1 uint32) int64 {
+	d := int64(u0) - int64(u1)
+	if d < 0 {
+		return -d
+	}
+	return d
+}
+
+// averageDelta returns the average delta in RGB space. The two images must
+// have the same bounds.
+func averageDelta(m0, m1 image.Image) int64 {
+	b := m0.Bounds()
+	var sum, n int64
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			c0 := m0.At(x, y)
+			c1 := m1.At(x, y)
+			r0, g0, b0, _ := c0.RGBA()
+			r1, g1, b1, _ := c1.RGBA()
+			sum += delta(r0, r1)
+			sum += delta(g0, g1)
+			sum += delta(b0, b1)
+			n += 3
+		}
+	}
+	return sum / n
+}
+
+// TestRoundtrip3 tests that encoding and decoding an image use JPEG compression.
+func TestRoundtrip3(t *testing.T) {
+	img, err := openImage("video-001.tiff")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := new(bytes.Buffer)
+	err = Encode(out, img, &Options{Compression: JPEG})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img2, err := Decode(&buffer{buf: out.Bytes()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := int64(6 << 8)
+	if got := averageDelta(img, img2); got > want {
+		t.Errorf("average delta too high; got %d, want <= %d", got, want)
+	}
+}
+
 func benchmarkEncode(b *testing.B, name string, pixelSize int) {
 	b.Helper()
 	img, err := openImage(name)


### PR DESCRIPTION
Add read/write support for TIFF JPEG-based compression.
Additionally, I have tested reading large size images export by photoshop and gimp.

Fixes [golang/go#23115](https://github.com/golang/go/issues/23115)