### PR TITLE
all: update golang.org/x/text for CVE-2021-38561

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module golang.org/x/image
 
 go 1.12
 
-require golang.org/x/text v0.3.6
+require golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,3 @@
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This should avoid flagging dependent projects as being vulnerable to https://deps.dev/advisory/OSV/GO-2021-0113.