### PR TITLE
Fix opentype.Face compliace with font.Face

### DIFF
--- a/font/opentype/opentype.go
+++ b/font/opentype/opentype.go
@@ -256,14 +256,16 @@ func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask imag
 
 // GlyphBounds satisfies the font.Face interface.
 func (f *Face) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.Int26_6, ok bool) {
-	bounds, advance, err := f.f.GlyphBounds(&f.buf, f.index(r), f.scale, f.hinting)
-	return bounds, advance, err == nil
+	index := f.index(r)
+	bounds, advance, err := f.f.GlyphBounds(&f.buf, index, f.scale, f.hinting)
+	return bounds, advance, err == nil || index == 0
 }
 
 // GlyphAdvance satisfies the font.Face interface.
 func (f *Face) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {
-	advance, err := f.f.GlyphAdvance(&f.buf, f.index(r), f.scale, f.hinting)
-	return advance, err == nil
+	index := f.index(r)
+	advance, err := f.f.GlyphAdvance(&f.buf, index, f.scale, f.hinting)
+	return advance, err == nil || index == 0
 }
 
 func (f *Face) index(r rune) sfnt.GlyphIndex {

--- a/font/opentype/opentype.go
+++ b/font/opentype/opentype.go
@@ -145,7 +145,7 @@ func (f *Face) Kern(r0, r1 rune) fixed.Int26_6 {
 // Glyph satisfies the font.Face interface.
 func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask image.Image, maskp image.Point, advance fixed.Int26_6, ok bool) {
 	x, err := f.f.GlyphIndex(&f.buf, r)
-	if err != nil {
+	if x == 0 err != nil {
 		return image.Rectangle{}, nil, image.Point{}, 0, false
 	}
 

--- a/font/opentype/opentype.go
+++ b/font/opentype/opentype.go
@@ -258,14 +258,14 @@ func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask imag
 func (f *Face) GlyphBounds(r rune) (bounds fixed.Rectangle26_6, advance fixed.Int26_6, ok bool) {
 	index := f.index(r)
 	bounds, advance, err := f.f.GlyphBounds(&f.buf, index, f.scale, f.hinting)
-	return bounds, advance, err == nil || index == 0
+	return bounds, advance, err == nil && index != 0
 }
 
 // GlyphAdvance satisfies the font.Face interface.
 func (f *Face) GlyphAdvance(r rune) (advance fixed.Int26_6, ok bool) {
 	index := f.index(r)
 	advance, err := f.f.GlyphAdvance(&f.buf, index, f.scale, f.hinting)
-	return advance, err == nil || index == 0
+	return advance, err == nil && index != 0
 }
 
 func (f *Face) index(r rune) sfnt.GlyphIndex {

--- a/font/opentype/opentype.go
+++ b/font/opentype/opentype.go
@@ -145,7 +145,7 @@ func (f *Face) Kern(r0, r1 rune) fixed.Int26_6 {
 // Glyph satisfies the font.Face interface.
 func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask image.Image, maskp image.Point, advance fixed.Int26_6, ok bool) {
 	x, err := f.f.GlyphIndex(&f.buf, r)
-	if x == 0 err != nil {
+	if err != nil {
 		return image.Rectangle{}, nil, image.Point{}, 0, false
 	}
 
@@ -251,7 +251,7 @@ func (f *Face) Glyph(dot fixed.Point26_6, r rune) (dr image.Rectangle, mask imag
 	}
 	f.rast.Draw(&f.mask, f.mask.Bounds(), image.Opaque, image.Point{})
 
-	return dr, &f.mask, f.mask.Rect.Min, advance, true
+	return dr, &f.mask, f.mask.Rect.Min, advance, x != 0
 }
 
 // GlyphBounds satisfies the font.Face interface.


### PR DESCRIPTION
This adds an additional check to see if the glyph exists before proceeding past the error check, solving [this issue](https://github.com/golang/go/issues/58252).