### PR TITLE
ccitt: use faster strconv.Itoa

### DIFF
--- a/ccitt/gen.go
+++ b/ccitt/gen.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 )
 
 var debug = flag.Bool("debug", false, "")
@@ -115,7 +116,7 @@ func (n *node) String() string {
 		return "0"
 	}
 	if n.branchIndex > 0 {
-		return fmt.Sprintf("%d", n.branchIndex)
+		return strconv.Itoa(int(n.branchIndex))
 	}
 	return fmt.Sprintf("^%d", n.val)
 }


### PR DESCRIPTION
than fmt.Sprintf("%d"

Found via `git grep 'fmt.Sprintf("%d",'`

Fixed with gotiti cf https://github.com/catenacyber/gotiti