### PR TITLE
tiff decode error when it has alpha channel

### DIFF
--- a/tiff/reader.go
+++ b/tiff/reader.go
@@ -539,6 +539,8 @@ func newDecoder(r io.Reader) (*decoder, error) {
 			}
 		case 4:
 			switch d.firstVal(tExtraSamples) {
+			case 0:
+				fallthrough
 			case 1:
 				d.mode = mRGBA
 				if d.bpp == 16 {


### PR DESCRIPTION
see https://github.com/golang/go/issues/11413

if tiff file use mode=rgb, and saved with alpha channel, it will error message

> tiff: invalid format: wrong number of samples for RGB