### PR TITLE
x/image/font/sfnt: fix io.EOF in ParseReaderAt on fonts with useMarkFilteringSet

### DIFF
--- a/font/sfnt/gpos.go
+++ b/font/sfnt/gpos.go
@@ -95,6 +95,11 @@ lookupTables:
 		switch lookupType := u16(buf); lookupType {
 		case 2: // PairPos table
 		case 9:
+			// Flags to check before updating subTableOffsets
+			if flags&0x0010 > 0 {
+				// useMarkFilteringSet enabled, skip as it is not supported
+				continue
+			}
 			// Extension Positioning table defines an additional u32 offset
 			// to allow subtables to exceed the 16-bit limit.
 			for i := range subTableOffsets {
@@ -111,11 +116,6 @@ lookupTables:
 				subTableOffsets[i] += int(u32(buf[4:]))
 			}
 		default: // other types are not supported
-			continue
-		}
-
-		if flags&0x0010 > 0 {
-			// useMarkFilteringSet enabled, skip as it is not supported
 			continue
 		}
 


### PR DESCRIPTION
Fixes an io.EOF returned by ParseReaderAt when parsing fonts with a
GPOS Extension lookup (type 9) and the useMarkFilteringSet flag set.

Fixes golang/go#79489