### PR TITLE
bmp: reject images exceeding 128 megapixels on 64-bit platforms

### DIFF
--- a/bmp/reader.go
+++ b/bmp/reader.go
@@ -202,6 +202,16 @@ func decodeConfig(r io.Reader) (config image.Config, bitsPerPixel int, topDown b
 	if _, ok := safemath.Mul3(width, height, 4); !ok {
 		return image.Config{}, 0, false, false, ErrUnsupported
 	}
+	// Limit total pixel count to prevent excessive memory allocation on
+	// 64-bit platforms from attacker-controlled BMP header dimensions.
+	// safemath.Mul3 above only prevents integer overflow; on 64-bit systems
+	// a 16384x16384 image passes that check yet allocates 1 GB of memory.
+	// This limit is consistent with the TIFF decoder (CVE-2026-33809) and
+	// the VP8L decoder fix (golang.org/x/image PR #31).
+	const maxPixels = 1 << 27 // 128 megapixels; 512 MB at 4 bytes/pixel
+	if int64(width)*int64(height) > maxPixels {
+		return image.Config{}, 0, false, false, ErrUnsupported
+	}
 	// We only support 1 plane and 8, 24 or 32 bits per pixel and no
 	// compression.
 	planes, bpp, compression := readUint16(b[26:28]), readUint16(b[28:30]), readUint32(b[30:34])

--- a/bmp/reader_test.go
+++ b/bmp/reader_test.go
@@ -220,3 +220,32 @@ func (b bmpBuilder) Bytes() []byte {
 	binary.LittleEndian.PutUint32(buf[2:], uint32(len(buf))) // file size
 	return buf
 }
+
+// TestDecodeOversizedDimensions verifies that a crafted BMP file claiming
+// 16384x16384 pixels is rejected without allocating ~1 GB of memory.
+// This is a regression test for the incomplete fix in commit 38fd2207:
+// safemath.Mul3 only prevents integer overflow, but 16384*16384*4 =
+// 1,073,741,824 fits in int64 without overflow, so the check passes on
+// 64-bit platforms. The maxPixels guard blocks the allocation.
+func TestDecodeOversizedDimensions(t *testing.T) {
+	// 54-byte BMP claiming 16384x16384 @ 32bpp with pixel data past EOF.
+	// safemath.Mul3(16384, 16384, 4) = 1,073,741,824 → ok=true (no overflow).
+	// Without the maxPixels check, this triggers a 1 GB allocation on amd64.
+	payload := bmpBuilder{
+		width:        16384,
+		height:       16384,
+		planes:       1,
+		bitsPerPixel: 32,
+	}.Bytes()
+
+	_, err := Decode(bytes.NewReader(payload))
+	if err == nil {
+		t.Fatal("Decode: expected error for oversized BMP, got nil")
+	}
+
+	// Also verify DecodeConfig is rejected.
+	_, err = DecodeConfig(bytes.NewReader(payload))
+	if err == nil {
+		t.Fatal("DecodeConfig: expected error for oversized BMP, got nil")
+	}
+}


### PR DESCRIPTION
Fix incomplete memory exhaustion guard in the BMP decoder for 64-bit
platforms.

The safemath.Mul3 check added in CL 787680 prevents integer overflow
but does not cap large-but-valid allocations on 64-bit systems. A
16384x16384 image at 32bpp passes the overflow check and causes a
1 GB allocation in image.NewNRGBA before any pixel data is read.

Add a pixel-count limit of 1<<27 (128 megapixels) consistent with
the TIFF decoder fix for CVE-2026-33809.

A regression test verifies the 54-byte attack file is rejected
without triggering the allocation.

Fixes golang/go#80169