### PR TITLE
bmp: add 1, 2 and 4 bits-per-pixel palettes decode documentation

### DIFF
--- a/bmp/reader.go
+++ b/bmp/reader.go
@@ -127,7 +127,7 @@ func decodeNRGBA(r io.Reader, c image.Config, topDown, allowAlpha bool) (image.I
 }
 
 // Decode reads a BMP image from r and returns it as an image.Image.
-// Limitation: The file must be 8, 24 or 32 bits per pixel.
+// Limitation: The file must be 1, 2, 4, 8, 24 or 32 bits per pixel.
 func Decode(r io.Reader) (image.Image, error) {
 	c, bpp, topDown, allowAlpha, err := decodeConfig(r)
 	if err != nil {
@@ -146,7 +146,7 @@ func Decode(r io.Reader) (image.Image, error) {
 
 // DecodeConfig returns the color model and dimensions of a BMP image without
 // decoding the entire image.
-// Limitation: The file must be 8, 24 or 32 bits per pixel.
+// Limitation: The file must be 1, 2, 4, 8, 24 or 32 bits per pixel.
 func DecodeConfig(r io.Reader) (image.Config, error) {
 	config, _, _, _, err := decodeConfig(r)
 	return config, err


### PR DESCRIPTION
This was not properly updated in https://github.com/golang/image/pull/22

Updates https://github.com/golang/go/issues/58005
Updates https://github.com/golang/go/issues/58005